### PR TITLE
fixed an issue with the pagination numbers

### DIFF
--- a/addon/components/number-pagination.js
+++ b/addon/components/number-pagination.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
   }),
   current: Ember.computed('page', {
     get() {
-      return this.get('page') ? this.get('page') + 1 : 1;
+      return this.get('page') ? parseInt(this.get('page')) + 1 : 1;
     },
     set(key, value) {
       this.set('page', value - 1);


### PR DESCRIPTION
The calculation of the 'current' wasn't correct. Javascript 'concated' the 1 to the 'page' string and not added the two numbers together.